### PR TITLE
fix: parameterize ORG name for OPDK

### DIFF
--- a/bin/amu
+++ b/bin/amu
@@ -302,7 +302,7 @@ elif [ "$OBJECT" = "kvms" ]; then
             check_options "CASS_IP"
             check_commands "$CASS_CLI"
 
-            echo -e "use keyvaluemap;\nget keyvaluemaps_r21[org];" | $CASS_CLI -h $CASS_IP > $EMIGRATE_DIR/$ORG-kvms.out
+            echo -e "use keyvaluemap;\nget keyvaluemaps_r21[${ORG}];" | $CASS_CLI -h $CASS_IP > $EMIGRATE_DIR/$ORG-kvms.out
         elif [ "$SRC" = "hybrid" ]; then
             # hybrid
             check_commands "kubectl"


### PR DESCRIPTION
While running:
`get keyvaluemaps_r21[org];`
It throws error because of hard-coded _org_ name.
This PR uses the `$ORG` set in the environment variables to get the keyvaluemaps.